### PR TITLE
Add libcrypt-openssl-rsa-perl to support Shairplay2 plugin

### DIFF
--- a/Dockerfile.linux-amd64
+++ b/Dockerfile.linux-amd64
@@ -12,7 +12,7 @@ ARG PACKAGE_URL=http://www.mysqueezebox.com/update/?version=${VERSION}&revision=
 
 # Install requirements and utilities
 RUN apt-get update && \
-    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl \
+    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl \
     iputils-ping \
     iproute2 \
     && apt-get clean

--- a/Dockerfile.linux-arm32v7
+++ b/Dockerfile.linux-arm32v7
@@ -14,7 +14,7 @@ ARG PACKAGE_URL=http://www.mysqueezebox.com/update/?version=${VERSION}&revision=
 
 # Install requirements and utilities
 RUN apt-get update && \
-    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl\
+    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl \
     iputils-ping \
     iproute2 \
     && apt-get clean

--- a/Dockerfile.linux-arm32v7
+++ b/Dockerfile.linux-arm32v7
@@ -14,7 +14,7 @@ ARG PACKAGE_URL=http://www.mysqueezebox.com/update/?version=${VERSION}&revision=
 
 # Install requirements and utilities
 RUN apt-get update && \
-    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl \
+    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl\
     iputils-ping \
     iproute2 \
     && apt-get clean

--- a/Dockerfile.linux-arm64v8
+++ b/Dockerfile.linux-arm64v8
@@ -14,7 +14,7 @@ ARG PACKAGE_URL=http://www.mysqueezebox.com/update/?version=${VERSION}&revision=
 
 # Install requirements and utilities
 RUN apt-get update && \
-    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl\
+    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl \
     iputils-ping \
     iproute2 \
     && apt-get clean

--- a/Dockerfile.linux-arm64v8
+++ b/Dockerfile.linux-arm64v8
@@ -14,7 +14,7 @@ ARG PACKAGE_URL=http://www.mysqueezebox.com/update/?version=${VERSION}&revision=
 
 # Install requirements and utilities
 RUN apt-get update && \
-    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl \
+    apt-get -y install curl wget nano faad flac lame sox libio-socket-ssl-perl libcrypt-openssl-rsa-perl\
     iputils-ping \
     iproute2 \
     && apt-get clean


### PR DESCRIPTION
The Shairplay2 plugin requires libcrypt-openssl-rsa-perl in order to work.  This just adds this lib.